### PR TITLE
Add makefile with useful commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+build:
+	docker build . -t capstone
+
+run:
+	docker run -p 4567:4567 -v $(PWD):/capstone -v /tmp/log:/root/.ros/ --rm -it capstone
+
+attach:
+	docker exec -it $(shell sh -c "docker ps| grep capstone" | awk '{print $$1}') /bin/bash


### PR DESCRIPTION
Adds the following make commands:

```
# builds the docker image
make build

# runs a container from the image
make run

# attaches to the running container (useful when several terminals are needed)
make attach
```