### PR TITLE
Update pillow when creating docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,8 @@ RUN apt-get install -y ros-$ROS_DISTRO-image-proc
 # socket io
 RUN apt-get install -y netbase
 
+RUN pip install pillow --upgrade
+
 RUN mkdir /capstone
 VOLUME ["/capstone"]
 VOLUME ["/root/.ros/log/"]


### PR DESCRIPTION
@kradio3 found out that when he turns on Camera in the simulator, cv_bridge crashed with the following error: `tuple index out of range`

It can be fixed by running `pip install pillow --upgrade` in the container.

I added the command the Dockerfile so that no manual work required to fix the issue.