### PR TITLE
Measuring DBW node performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ build
 devel
 
 profile.tmp
+
+data/dbw_test.rosbag.bag
+data/dbw_test.rosbag.bag.zip

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ profile.tmp
 
 data/dbw_test.rosbag.bag
 data/dbw_test.rosbag.bag.zip
+
+ros/src/twist_controller/brakes.csv
+ros/src/twist_controller/steers.csv
+ros/src/twist_controller/throttles.csv

--- a/Makefile
+++ b/Makefile
@@ -6,3 +6,8 @@ run:
 
 attach:
 	docker exec -it $(shell sh -c "docker ps| grep capstone" | awk '{print $$1}') /bin/bash
+
+test-init:
+	wget https://s3-us-west-1.amazonaws.com/udacity-selfdrivingcar/files/reference.bag.zip -O data/dbw_test.rosbag.bag.zip &&\
+	unzip data/dbw_test.rosbag.bag.zip -d data/ &&\
+	mv data/reference.bag data/dbw_test.rosbag.bag

--- a/steer_perf.md
+++ b/steer_perf.md
@@ -1,0 +1,8 @@
+# Steering Controller Performance
+
+### 2019-02-14
+
+Streeting controller from the walkthrough lesson.
+The `following_flag` in the `waypoint_follower` is always set to `False` to force the follower to always update twist commands.
+
+Performance: `Steering performance based on 1000 samples = 0.0845631461869925`

--- a/steer_perf.md
+++ b/steer_perf.md
@@ -1,8 +1,63 @@
 # Steering Controller Performance
 
+## Running Performance Test
+
+Run the following command to prepare the test data:
+
+```
+make test-init
+```
+
+Once done build and run the docker container
+
+```
+make build run
+```
+
+In the running container start the test node:
+
+```
+roslaunch src/twist_controller/launch/dbw_test.launch
+```
+
+You may see errors like this:
+
+```
+[ERROR] [1550117114.932990800]: Client [/dbw_test] wants topic /actual/brake_cmd to have datatype/md5s│Removing: /Users/nyukhalov/Library/Logs/Homebrew/zsh... (64B)
+um [dbw_mkz_msgs/BrakeCmd/899b0f3ef31bf0a48497d65b424a1975], but our version has [dbw_mkz_msgs/BrakeCm│Removing: /Users/nyukhalov/Library/Logs/Homebrew/theora... (64B)
+d/c0d20e1056976680942e85ab0959826c]. Dropping connection.
+```
+
+The reason of the errors is unknown yet, but looks like we can simply ignore them.
+
+Wait until test node is finished. The following log message indicates that the node finished:
+
+```
+[dbw_test-3] process has finished cleanly
+```
+
+Now you can exit from the container, we don't need it anymore.
+
+Run the `steering_perf.py` script from the util directory to calculate overall error:
+
+```
+python util/steering_perf.py
+```
+
+The output will look like this:
+
+```
+Steering performance based on 1000 samples = 0.0782663364056498
+```
+
+## Perf Tune
+
 ### 2019-02-14
 
 Streeting controller from the walkthrough lesson.
 The `following_flag` in the `waypoint_follower` is always set to `False` to force the follower to always update twist commands.
 
-Performance: `Steering performance based on 1000 samples = 0.0845631461869925`
+Performance: 
+- `Steering performance based on 1000 samples = 0.0845631461869925`
+- `Steering performance based on 1000 samples = 0.0782663364056498`
+- `Steering performance based on 1000 samples = 0.1017662478219718`

--- a/util/steering_perf.py
+++ b/util/steering_perf.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+
+import csv
+import math
+
+def main():
+    steer_file = "ros/src/twist_controller/steers.csv"
+    mse = 0
+    cnt = 0
+    with open(steer_file, 'r') as csvfile:
+        reader = csv.DictReader(csvfile, delimiter=',')
+        for row in reader:
+            cnt += 1
+            actual = float(row['actual'])
+            proposed = float(row['proposed'])
+            mse += abs(actual - proposed)
+    mse = mse / cnt
+    print('Steering performance based on %d samples = %.16f' % (cnt, mse))
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Before tuning steering I wanted to have an ability to measure how it performs before tuning.
This will help us to understand whether tunning improves steering performance.

- Modifies the `dbw_test` node to gather a limited number of samples.
- Adds the `util/steering_perf.py` script to calculate MSE for steering logs.
- Adds the `test-init` make command to prepare the test bag.