### PR TITLE
Enhance steering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ data/dbw_test.rosbag.bag.zip
 ros/src/twist_controller/brakes.csv
 ros/src/twist_controller/steers.csv
 ros/src/twist_controller/throttles.csv
+
+.vscode/

--- a/ros/launch/styx.launch
+++ b/ros/launch/styx.launch
@@ -6,8 +6,14 @@
     <!--DBW Node -->
     <include file="$(find twist_controller)/launch/dbw_sim.launch"/>
 
+    <!--DBW Node Performance -->
+    <include file="$(find twist_controller)/launch/dbw_perf.launch"/>
+
     <!--Waypoint Loader -->
     <include file="$(find waypoint_loader)/launch/waypoint_loader.launch"/>
+    
+    <!-- use instead the above line to test on site -->
+    <!-- <include file="$(find waypoint_loader)/launch/waypoint_loader_site.launch"/> -->
 
     <!--Waypoint Follower Node -->
     <include file="$(find waypoint_follower)/launch/pure_pursuit.launch"/>

--- a/ros/src/twist_controller/dbw_node.py
+++ b/ros/src/twist_controller/dbw_node.py
@@ -41,9 +41,22 @@ class DBWNode(object):
         decel_limit = rospy.get_param('~decel_limit', -5)
         accel_limit = rospy.get_param('~accel_limit', 1.)
         wheel_radius = rospy.get_param('~wheel_radius', 0.2413)
+
+        # The wheelbase is the distance between the centers of the front and rear wheels.
+        # https://en.wikipedia.org/wiki/Wheelbase
         wheel_base = rospy.get_param('~wheel_base', 2.8498)
+        
+        # Steering ratio refers to the ratio between the turn of the steering wheel (in degrees) 
+        # or handlebars and the turn of the wheels (in degrees).
+        # https://en.wikipedia.org/wiki/Steering_ratio
+        #
+        # In this case, a turn of the steering wheel 14.8 degrees
+        # causes the wheels to turn 1 degree
         steer_ratio = rospy.get_param('~steer_ratio', 14.8)
+
+        # Maximum lateral acceleration
         max_lat_accel = rospy.get_param('~max_lat_accel', 3.)
+
         max_steer_angle = rospy.get_param('~max_steer_angle', 8.)
 
         self.steer_pub = rospy.Publisher('/vehicle/steering_cmd',
@@ -58,8 +71,8 @@ class DBWNode(object):
 
         self.dbw_enabled = False
         self.current_vel = None
-        self.linear_vel = None
-        self.angular_vel = None
+        self.target_linear_vel = None
+        self.target_angular_vel = None
 
         # Initialize subscribers
         rospy.Subscriber('/vehicle/dbw_enabled', Bool, self.dbw_enabled_cb)
@@ -75,14 +88,14 @@ class DBWNode(object):
             rate.sleep()
 
     def loop_iter(self):
-        if None in (self.current_vel, self.linear_vel, self.angular_vel):
+        if None in (self.current_vel, self.target_linear_vel, self.target_angular_vel):
             # don't do anything if the fields are not initialized yet
             return
 
         throttle, brake, steering = self.controller.control(self.dbw_enabled, 
                                                             self.current_vel, 
-                                                            self.linear_vel, 
-                                                            self.angular_vel)
+                                                            self.target_linear_vel, 
+                                                            self.target_angular_vel)
         if self.dbw_enabled:
             self.publish(throttle, brake, steering)
 
@@ -90,8 +103,8 @@ class DBWNode(object):
         self.dbw_enabled = is_dbw_enabled
 
     def twist_cb(self, msg):
-        self.linear_vel =  msg.twist.linear.x
-        self.angular_vel = msg.twist.angular.z
+        self.target_linear_vel =  msg.twist.linear.x
+        self.target_angular_vel = msg.twist.angular.z
 
     def velocity_cb(self, msg):
         self.current_vel = msg.twist.linear.x

--- a/ros/src/twist_controller/dbw_node_perf.py
+++ b/ros/src/twist_controller/dbw_node_perf.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python
+
+import rospy
+from std_msgs.msg import Bool
+from dbw_mkz_msgs.msg import ThrottleCmd, SteeringCmd, BrakeCmd, SteeringReport
+from geometry_msgs.msg import TwistStamped, PoseStamped
+from styx_msgs.msg import Lane, Waypoint
+from scipy.spatial import KDTree
+import math
+
+class DBWNodePerf(object):
+    def __init__(self):
+        rospy.init_node('dbw_node_perf')
+
+        self.freq = 2 # Hz
+        self.num_samples = 240 # which will be gathered after two-minute driving
+        self.mse_acc = 0
+        self.mse_cnt = 0
+
+        self.dbw_enabled = False
+        self.current_vel = None
+        self.current_pose_xy = None
+        self.target_linear_vel = None
+        self.target_angular_vel = None
+        self.base_waypoints = None
+        self.waypoints_2d = None
+        self.waypoint_tree = None        
+
+        # Initialize subscribers
+        rospy.Subscriber('/vehicle/dbw_enabled', Bool, self.dbw_enabled_cb)
+        rospy.Subscriber('/current_velocity', TwistStamped, self.current_vel_cb)
+        rospy.Subscriber('/current_pose', PoseStamped, self.current_pose_cb)
+        rospy.Subscriber('/base_waypoints', Lane, self.waypoints_cb)
+
+        self.loop()
+
+    def loop(self):
+        rate = rospy.Rate(self.freq)
+        while not rospy.is_shutdown():
+            try:
+                self.loop_iter()
+                rate.sleep()
+            except (rospy.ROSInterruptException, KeyboardInterrupt):
+                rospy.logwarn('Interrupted. Shutting down the node')
+                pass
+
+        mse = self.mse_acc / self.mse_cnt
+        rospy.loginfo('Steering performance based on %d samples = %.16f' % (self.mse_cnt, mse))
+        
+    def loop_iter(self):
+        if not self.dbw_enabled:
+            return
+
+        if self.current_pose_xy and self.waypoint_tree:
+            closest_waypoint_idx = self.get_nearest_waypoint_idx()
+            self.update_error(closest_waypoint_idx)
+
+    def shutdown(self, reason):
+        rospy.logwarn("Shutdown the node with the reason: %s" % reason)
+        rospy.signal_shutdown(reason)
+
+    def dbw_enabled_cb(self, msg):
+        self.dbw_enabled = msg
+
+    def current_vel_cb(self, msg):
+        self.current_vel = msg.twist.linear.x
+
+    def current_pose_cb(self, msg):
+        self.current_pose_xy = [msg.pose.position.x, msg.pose.position.y]
+
+    def waypoints_cb(self, waypoints):
+        self.base_waypoints = waypoints
+        if not self.waypoints_2d:
+            self.waypoints_2d = [[w.pose.pose.position.x, w.pose.pose.position.y] for w in waypoints.waypoints]
+            self.waypoint_tree = KDTree(self.waypoints_2d)
+
+    def get_nearest_waypoint_idx(self):
+        x = self.current_pose_xy[0]
+        y = self.current_pose_xy[1]
+        closest_idx = self.waypoint_tree.query([x, y], 1)[1]
+        return closest_idx
+
+    def update_error(self, closest_waypoint_idx):
+        if self.mse_cnt >= self.num_samples:
+            self.shutdown("mse_cnt exceeds num_samples (%d >= %d)" % (self.mse_cnt, self.num_samples))
+            return
+
+        closest_wp = self.base_waypoints.waypoints[closest_waypoint_idx]
+        # wp_vel = self.get_waypoint_velocity(closest_wp)
+        # err_vel = wp_vel - self.current_vel
+        err_pose_x = closest_wp.pose.pose.position.x - self.current_pose_xy[0]
+        err_pose_y = closest_wp.pose.pose.position.y - self.current_pose_xy[1]
+
+        self.mse_cnt += 1
+        self.mse_acc += err_pose_x * err_pose_x
+        self.mse_acc += err_pose_y * err_pose_y
+
+    def get_waypoint_velocity(self, waypoint):
+        return waypoint.twist.twist.linear.x        
+
+if __name__ == '__main__':
+    DBWNodePerf()

--- a/ros/src/twist_controller/dbw_node_perf.py
+++ b/ros/src/twist_controller/dbw_node_perf.py
@@ -12,8 +12,8 @@ class DBWNodePerf(object):
     def __init__(self):
         rospy.init_node('dbw_node_perf')
 
-        self.freq = 2 # Hz
-        self.num_samples = 240 # which will be gathered after two-minute driving
+        self.freq = 40 # Hz
+        self.num_samples = 120 * self.freq # which will be gathered after two-minute driving
         self.mse_acc = 0
         self.mse_cnt = 0
 

--- a/ros/src/twist_controller/dbw_test.py
+++ b/ros/src/twist_controller/dbw_test.py
@@ -53,19 +53,24 @@ class DBWTestNode(object):
 
         # limits the max number of gathered samples
         # use None to not use the limit
-        self.max_samples_steering = 1000
+        self.max_samples_steering = 1500
         self.max_samples_throttle = None
         self.max_samples_brake = None
 
         self.loop()
 
     def shutdown(self, reason):
+        rospy.logwarn("Shutdown the node with the reason: %s" % reason)
         rospy.signal_shutdown(reason)
 
     def loop(self):
         rate = rospy.Rate(10) # 10Hz
         while not rospy.is_shutdown():
-            rate.sleep()
+            try:
+                rate.sleep()
+            except (rospy.ROSInterruptException, KeyboardInterrupt):
+                rospy.logwarn("Interrupted")
+                pass
         fieldnames = ['actual', 'proposed']
 
         with open(self.steerfile, 'w') as csvfile:

--- a/ros/src/twist_controller/launch/dbw_perf.launch
+++ b/ros/src/twist_controller/launch/dbw_perf.launch
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<launch>
+    <node pkg="twist_controller" type="dbw_node_perf.py" name="dbw_node_perf"></node>
+</launch>

--- a/ros/src/twist_controller/lowpass.py
+++ b/ros/src/twist_controller/lowpass.py
@@ -2,7 +2,7 @@
 class LowPassFilter(object):
     def __init__(self, tau, ts):
         self.a = 1. / (tau / ts + 1.)
-        self.b = tau / ts / (tau / ts + 1.);
+        self.b = tau / ts / (tau / ts + 1.)
 
         self.last_val = 0.
         self.ready = False

--- a/ros/src/twist_controller/twist_controller.py
+++ b/ros/src/twist_controller/twist_controller.py
@@ -33,22 +33,22 @@ class Controller(object):
 
         self.last_time = rospy.get_time()
 
-    def control(self, dbw_enabled, current_vel, linear_vel, angular_vel):
+    def control(self, dbw_enabled, current_vel, target_linear_vel, target_angular_vel):
         if not dbw_enabled:
             self.throttle_controller.reset()
             return 0, 0, 0
 
         current_vel = self.vel_lpf.filt(current_vel)
 
-        steering = self.yaw_controller.get_steering(linear_vel, angular_vel, current_vel)
+        steering = self.yaw_controller.get_steering(target_linear_vel, target_angular_vel, current_vel)
 
-        # rospy.logwarn("Target linear vel: %f" % linear_vel)
-        # rospy.logwarn("Target angular vel: %f" % angular_vel)
+        # rospy.logwarn("Target linear vel: %f" % target_linear_vel)
+        # rospy.logwarn("Target angular vel: %f" % target_angular_vel)
         # rospy.logwarn("Current vel: %f" % current_vel)
         # rospy.logwarn("Filtered current vel: %f" % self.vel_lpf.get())
         # rospy.logwarn("Steering: %f" % steering)
 
-        vel_error = linear_vel - current_vel
+        vel_error = target_linear_vel - current_vel
         self.last_vel = current_vel
 
         current_time = rospy.get_time()
@@ -58,7 +58,7 @@ class Controller(object):
         throttle = self.throttle_controller.step(vel_error, sample_time)
         brake = 0
 
-        if linear_vel == 0. and current_vel < 0.1:
+        if target_linear_vel == 0. and current_vel < 0.1:
             throttle = 0
             brake = 700
         elif throttle < .1 and vel_error < 0:

--- a/ros/src/twist_controller/yaw_controller.py
+++ b/ros/src/twist_controller/yaw_controller.py
@@ -1,5 +1,8 @@
 from math import atan
 
+def clamp(n, minn, maxn):
+    return max(min(maxn, n), minn)
+
 class YawController(object):
     def __init__(self, wheel_base, steer_ratio, min_speed, max_lat_accel, max_steer_angle):
         self.wheel_base = wheel_base
@@ -7,19 +10,37 @@ class YawController(object):
         self.min_speed = min_speed
         self.max_lat_accel = max_lat_accel
 
-        self.min_angle = -max_steer_angle
-        self.max_angle = max_steer_angle
+        self.min_steer_angle = -max_steer_angle
+        self.max_steer_angle = max_steer_angle
 
+    def get_steering(self, target_linear_vel, target_angular_vel, current_vel):
+        # TODO: find out what's the reason to adjust the target angular velocity as below
+        # angular_vel = current_vel * target_angular_vel / target_linear_vel if abs(target_linear_vel) > 0. else 0.
+        angular_vel = target_angular_vel
 
-    def get_angle(self, radius):
-        angle = atan(self.wheel_base / radius) * self.steer_ratio
-        return max(self.min_angle, min(self.max_angle, angle))
+        # don't steer if angular velocity is about 0
+        if abs(angular_vel) <= 0.:
+            return 0.0
 
-    def get_steering(self, linear_velocity, angular_velocity, current_velocity):
-        angular_velocity = current_velocity * angular_velocity / linear_velocity if abs(linear_velocity) > 0. else 0.
+        # Limit angular velocity to not exceed the max lateral acceleration.
+        # Read more about lateral acceleration: https://www.mrwaynesclass.com/circular/notes/corner/home.htm 
+        if abs(current_vel) > 0.1:
+            # lat_accel = V*V/R = V*w => w = lat_accel/V
+            max_angular_vel = abs(self.max_lat_accel / current_vel)
+            angular_vel = clamp(angular_vel, -max_angular_vel, max_angular_vel)
 
-        if abs(current_velocity) > 0.1:
-            max_yaw_rate = abs(self.max_lat_accel / current_velocity)
-            angular_velocity = max(-max_yaw_rate, min(max_yaw_rate, angular_velocity))
+        # Find out the radius the car must follow to achieve the target angular velocity
+        vel = max(current_vel, self.min_speed)
+        turning_radius = vel / angular_vel # w = V/r => r = V/w
 
-        return self.get_angle(max(current_velocity, self.min_speed) / angular_velocity) if abs(angular_velocity) > 0. else 0.0
+        # Knowing the radius identify what should be the steering angle
+        return self.get_steer_angle(turning_radius)
+
+    def get_steer_angle(self, turning_radius):
+        # Take a loot at the bicycle model.
+        # https://nabinsharma.wordpress.com/2014/01/02/kinematics-of-a-robot-bicycle-model/
+        #
+        # tan(wheel_angle) = wheel_base / turning_radius
+        wheel_angle = atan(self.wheel_base / turning_radius)
+        steer_angle = wheel_angle * self.steer_ratio
+        return clamp(steer_angle, self.min_steer_angle, self.max_steer_angle)

--- a/steer_perf.md
+++ b/steer_perf.md
@@ -1,6 +1,46 @@
 # Steering Controller Performance
 
-## Running Performance Test
+## Measuring the car's position MSE
+
+The `dbw_node_perf` node located in the `ros/src/twist_controller/dbw_node_perf.py` measures the mean squared error (MSE) of the car's position.
+
+The main launch file `launch/styx.launch` has been modified to launch the `dbw_node_perf` node. So no manual work required. Just launch ROS along with the simulator as usually.
+
+The node aggregates the MSE error and prints an info log message to stdout once measuring finished.
+Quite ofter the node stops before the message gets printed so see log files to find the message.
+
+## Tuning Log
+
+Using the `dbw_node_perf` to calculate MSE of the car's position.
+
+### 2019-02-16
+
+Track: Highway
+Number of samples: 240
+
+**The MSE error when don't adjust `target_angular_vel` in the yaw controller:**
+
+```
+Steering performance based on 240 samples = 0.0872404958333297
+Steering performance based on 240 samples = 0.0810669833333386
+```
+
+**The MSE error of the walkthrough code with updated waypoint follower:**
+
+```
+Steering performance based on 240 samples = 0.0828155124999976
+Steering performance based on 240 samples = 0.0769877833333294
+```
+
+**The MSE error of the walkthough code:**
+
+```
+Steering performance based on 240 samples = 0.1451740916666643
+```
+
+## Running Performance Test (obsolete)
+
+> this doesn't really help to measure the steering performance. Please use the `dbw_node_perf` node instead.
 
 Run the following command to prepare the test data:
 
@@ -49,15 +89,3 @@ The output will look like this:
 ```
 Steering performance based on 1000 samples = 0.0782663364056498
 ```
-
-## Perf Tune
-
-### 2019-02-14
-
-Streeting controller from the walkthrough lesson.
-The `following_flag` in the `waypoint_follower` is always set to `False` to force the follower to always update twist commands.
-
-Performance: 
-- `Steering performance based on 1000 samples = 0.0845631461869925`
-- `Steering performance based on 1000 samples = 0.0782663364056498`
-- `Steering performance based on 1000 samples = 0.1017662478219718`

--- a/steer_perf.md
+++ b/steer_perf.md
@@ -21,21 +21,22 @@ Number of samples: 240
 **The MSE error when don't adjust `target_angular_vel` in the yaw controller:**
 
 ```
-Steering performance based on 240 samples = 0.0872404958333297
-Steering performance based on 240 samples = 0.0810669833333386
+Steering performance based on 4800 samples = 0.0819861014583316
+Steering performance based on 4800 samples = 0.0821451122916661
 ```
 
 **The MSE error of the walkthrough code with updated waypoint follower:**
 
 ```
-Steering performance based on 240 samples = 0.0828155124999976
-Steering performance based on 240 samples = 0.0769877833333294
+Steering performance based on 4800 samples = 0.0863728854166650
+Steering performance based on 4800 samples = 0.0862604252083322
 ```
 
 **The MSE error of the walkthough code:**
 
 ```
-Steering performance based on 240 samples = 0.1451740916666643
+Steering performance based on 4800 samples = 0.1356663893749996
+Steering performance based on 4800 samples = 0.1763829977083291
 ```
 
 ## Running Performance Test (obsolete)

--- a/util/steering_perf.py
+++ b/util/steering_perf.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 import csv
-import math
 
 def main():
     steer_file = "ros/src/twist_controller/steers.csv"
@@ -13,7 +12,8 @@ def main():
             cnt += 1
             actual = float(row['actual'])
             proposed = float(row['proposed'])
-            mse += abs(actual - proposed)
+            diff = actual - proposed
+            mse += diff*diff
     mse = mse / cnt
     print('Steering performance based on %d samples = %.16f' % (cnt, mse))
 


### PR DESCRIPTION
This adds the `dbw_node_perf` node which measures the car's position MSE.
This was used as an indicator of steering performance while trying to a better way to steer.
Please see [steer_perf.md](steer_perf.md) for more details.

After a few experiments, I could not find out how to make the steering algorithms significantly better.
The current logic which, as for me, works quite well:
- DBW Node walkthrough code (math-based approach)
- Disabled adjusting `target_angular_velocity` in the `YawController`
- The `waypoint_follower` is changed to always update twist commands.

The code was tested on both Highway and Test Lot tracks and performed well.

I think we don't need to invest more time on it right now.
This PR can is tested and can be merged.