### PR TITLE
tl_detector: process tl on receiving camera image

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,13 @@ make attach
 make test-init
 ```
 
+### Team Lead
+* [Elias Khsheibun](https://github.com/elias3) - elias3@gmail.com
 ### Team Members
-* [Elias Khsheibun](https://github.com/elias3)
-* [Roman Niukhalov](https://github.com/nyukhalov)
-* [Andrey Yaroshenko](https://github.com/kradio3)
-* [Nathan Sherrit](https://github.com/nathansherrit)
-* [Ragupathy Gopalakrishnan](https://github.com/ragu-git)
+* [Roman Niukhalov](https://github.com/nyukhalov) - r.nyukhalov@gmail.com
+* [Andrey Yaroshenko](https://github.com/kradio3) - kradio3@gmail.com
+* [Nathan Sherrit](https://github.com/nathansherrit) - nathansherrit@yahoo.com
+* [Ragupathy Gopalakrishnan](https://github.com/ragu-git) - Ragupathy.gopal@gmail.com
 
 ### Docs
 

--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -47,7 +47,6 @@ class TLDetector(object):
 
     def pose_cb(self, msg):
         self.pose = msg
-        self.process_traffic_lights()
 
     def waypoints_cb(self, waypoints):
         if not self.waypoint_tree:
@@ -66,6 +65,7 @@ class TLDetector(object):
 
         """
         self.camera_image = msg
+        self.process_traffic_lights()
 
     def is_stop_tl_state(self, tl_state):
         return tl_state == TrafficLight.RED or tl_state == TrafficLight.YELLOW


### PR DESCRIPTION
In the tl_detector we should only process the lights when we get an image, not a pose message. That way we aren't processing the same image multiple times if pose topic has a higher frequency